### PR TITLE
adding vector::erase_unordered

### DIFF
--- a/include/TINYSTL/buffer.h
+++ b/include/TINYSTL/buffer.h
@@ -160,7 +160,6 @@ namespace tinystl {
 		if (b->first + newsize > b->capacity)
 			buffer_reserve(b, (newsize * 3) / 2);
 
-		typedef T* pointer;
 		where = b->first + offset;
 		const size_t count = (size_t)(last - first);
 
@@ -176,12 +175,28 @@ namespace tinystl {
 	template<typename T, typename Alloc>
 	static inline T* buffer_erase(buffer<T, Alloc>* b, T* first, T* last) {
 		typedef T* pointer;
+		const size_t range = (last - first);
 		for (pointer it = last, end = b->last, dest = first; it != end; ++it, ++dest)
 			move(*dest, *it);
 
-		buffer_destroy_range(b->last - (last - first), b->last);
+		buffer_destroy_range(b->last - range, b->last);
 
-		b->last -= (last - first);
+		b->last -= range;
+		return first;
+	}
+
+	template<typename T, typename Alloc>
+	static inline T* buffer_erase_unordered(buffer<T, Alloc>* b, T* first, T* last) {
+		typedef T* pointer;
+		const size_t range = (last - first);
+		const size_t tail = (b->last - last);
+		pointer it = b->last - ((range < tail) ? range : tail);
+		for (pointer end = b->last, dest = first; it != end; ++it, ++dest)
+			move(*dest, *it);
+
+		buffer_destroy_range(b->last - range, b->last);
+
+		b->last -= range;
 		return first;
 	}
 

--- a/include/TINYSTL/vector.h
+++ b/include/TINYSTL/vector.h
@@ -85,6 +85,9 @@ namespace tinystl {
 		iterator erase(iterator where);
 		iterator erase(iterator first, iterator last);
 
+		iterator erase_unordered(iterator where);
+		iterator erase_unordered(iterator first, iterator last);
+
 	private:
 		buffer<T, Alloc> m_buffer;
 	};
@@ -249,6 +252,16 @@ namespace tinystl {
 	template<typename T, typename Alloc>
 	inline typename vector<T, Alloc>::iterator vector<T, Alloc>::erase(iterator first, iterator last) {
 		return buffer_erase(&m_buffer, first, last);
+	}
+
+	template<typename T, typename Alloc>
+	inline typename vector<T, Alloc>::iterator vector<T, Alloc>::erase_unordered(iterator where) {
+		return buffer_erase_unordered(&m_buffer, where, where + 1);
+	}
+
+	template<typename T, typename Alloc>
+	inline typename vector<T, Alloc>::iterator vector<T, Alloc>::erase_unordered(iterator first, iterator last) {
+		return buffer_erase_unordered(&m_buffer, first, last);
 	}
 }
 

--- a/test/vector_complex.cpp
+++ b/test/vector_complex.cpp
@@ -191,6 +191,37 @@ TEST(vector_complex_erase) {
 	CHECK(v[1] == "9");
 }
 
+TEST(vector_complex_erase_unordered) {
+	const complex array[10] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
+	typedef tinystl::vector<complex> vector;
+	vector v(array, array + 10);
+
+	complex first = *(v.begin());
+	vector::iterator it = v.erase_unordered(v.begin());
+	CHECK(it == v.begin());
+	CHECK(v.size() == 9);
+	CHECK( std::count(v.begin(), v.end(), first) == 0 );
+	for (it = v.begin(); it != v.end(); ++it) {
+		CHECK( std::count(v.begin(), v.end(), *it) == 1 );
+	}
+
+	complex last = *(v.end() - 1);
+	it = v.erase_unordered(v.end() - 1);
+	CHECK(it == v.end());
+	CHECK(v.size() == 8);
+	CHECK( std::count(v.begin(), v.end(), last) == 0 );
+	for (it = v.begin(); it != v.end(); ++it) {
+		CHECK( std::count(v.begin(), v.end(), *it) == 1 );
+	}
+
+	first = *(v.begin());
+	last = *(v.end() - 1);
+	v.erase_unordered(v.begin() + 1, v.end() - 1);
+	CHECK(v.size() == 2);
+	CHECK( std::count(v.begin(), v.end(), first) == 1 );
+	CHECK( std::count(v.begin(), v.end(), last) == 1 );
+}
+
 TEST(vector_complex_insert) {
 	const complex array[10] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
 	tinystl::vector<complex> v(array, array + 10);

--- a/test/vector_nodefault.cpp
+++ b/test/vector_nodefault.cpp
@@ -183,6 +183,37 @@ TEST(vector_nodefault_erase) {
 	CHECK(v[1] == "9");
 }
 
+TEST(vector_nodefault_erase_unordered) {
+	const nodefault array[10] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
+	typedef tinystl::vector<nodefault> vector;
+	vector v(array, array + 10);
+
+	nodefault first = *(v.begin());
+	vector::iterator it = v.erase_unordered(v.begin());
+	CHECK(it == v.begin());
+	CHECK(v.size() == 9);
+	CHECK( std::count(v.begin(), v.end(), first) == 0 );
+	for (it = v.begin(); it != v.end(); ++it) {
+		CHECK( std::count(v.begin(), v.end(), *it) == 1 );
+	}
+
+	nodefault last = *(v.end() - 1);
+	it = v.erase_unordered(v.end() - 1);
+	CHECK(it == v.end());
+	CHECK(v.size() == 8);
+	CHECK( std::count(v.begin(), v.end(), last) == 0 );
+	for (it = v.begin(); it != v.end(); ++it) {
+		CHECK( std::count(v.begin(), v.end(), *it) == 1 );
+	}
+
+	first = *(v.begin());
+	last = *(v.end() - 1);
+	v.erase_unordered(v.begin() + 1, v.end() - 1);
+	CHECK(v.size() == 2);
+	CHECK( std::count(v.begin(), v.end(), first) == 1 );
+	CHECK( std::count(v.begin(), v.end(), last) == 1 );
+}
+
 TEST(vector_nodefault_insert) {
 	const nodefault array[10] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
 	tinystl::vector<nodefault> v(array, array + 10);

--- a/test/vector_primitive.cpp
+++ b/test/vector_primitive.cpp
@@ -170,6 +170,37 @@ TEST(vector_erase) {
 	CHECK(v[1] == 9);
 }
 
+TEST(vector_erase_unordered) {
+	const int array[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+	typedef tinystl::vector<int> vector;
+	vector v(array, array + 10);
+
+	int first = *(v.begin());
+	vector::iterator it = v.erase_unordered(v.begin());
+	CHECK(it == v.begin());
+	CHECK(v.size() == 9);
+	CHECK( std::count(v.begin(), v.end(), first) == 0 );
+	for (it = v.begin(); it != v.end(); ++it) {
+		CHECK( std::count(v.begin(), v.end(), *it) == 1 );
+	}
+
+	int last = *(v.end() - 1);
+	it = v.erase_unordered(v.end() - 1);
+	CHECK(it == v.end());
+	CHECK(v.size() == 8);
+	CHECK( std::count(v.begin(), v.end(), last) == 0 );
+	for (it = v.begin(); it != v.end(); ++it) {
+		CHECK( std::count(v.begin(), v.end(), *it) == 1 );
+	}
+
+	first = *(v.begin());
+	last = *(v.end() - 1);
+	v.erase_unordered(v.begin() + 1, v.end() - 1);
+	CHECK(v.size() == 2);
+	CHECK( std::count(v.begin(), v.end(), first) == 1 );
+	CHECK( std::count(v.begin(), v.end(), last) == 1 );
+}
+
 TEST(vector_insert) {
 	const int array[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 	tinystl::vector<int> v(array, array + 10);


### PR DESCRIPTION
This adds methods for erasing elements from a vector without retaining the vectors ordering. The implementation moves tail elements into the place of erased elements, which results in only copying the number of elements removed as compared to the default erase which must copy all elements from the last removed element until the end of the vector. This is a faster erase to use when the order of elements is not important.
