### PR TITLE
Improvements to vector

### DIFF
--- a/include/TINYSTL/buffer.h
+++ b/include/TINYSTL/buffer.h
@@ -241,6 +241,26 @@ namespace tinystl {
 			new(placeholder(), where) T();
 	}
 
+	template<typename T, typename Alloc, typename Param>
+	static inline void buffer_append(buffer<T, Alloc>* b, const Param* param) {
+		if (b->capacity != b->last) {
+			new(placeholder(), b->last) T(*param);
+			++b->last;
+		} else {
+			buffer_insert(b, b->last, param, param + 1);
+		}
+	}
+
+	template<typename T, typename Alloc>
+	static inline void buffer_append(buffer<T, Alloc>* b) {
+		if (b->capacity != b->last) {
+			new(placeholder(), b->last) T();
+			++b->last;
+		} else {
+			buffer_insert(b, b->last, 1);
+		}
+	}
+
 	template<typename T, typename Alloc>
 	static inline T* buffer_erase(buffer<T, Alloc>* b, T* first, T* last) {
 		typedef T* pointer;

--- a/include/TINYSTL/buffer.h
+++ b/include/TINYSTL/buffer.h
@@ -180,9 +180,11 @@ namespace tinystl {
 			Alloc::static_deallocate(b->first, sizeof(T)*capacity);
 			b->capacity = b->first;
 		} else if (b->capacity != b->last) {
+			const size_t capacity = (size_t)(b->capacity - b->first);
 			const size_t size = (size_t)(b->last - b->first);
 			T* newfirst = (T*)Alloc::static_allocate(sizeof(T) * size);
 			buffer_move_urange(newfirst, b->first, b->last);
+			Alloc::static_deallocate(b->first, sizeof(T) * capacity);
 			b->first = newfirst;
 			b->last = newfirst + size;
 			b->capacity = b->last;

--- a/include/TINYSTL/vector.h
+++ b/include/TINYSTL/vector.h
@@ -232,15 +232,13 @@ namespace tinystl {
 	}
 
 	template<typename T, typename Alloc>
-	inline void vector<T, Alloc>::emplace_back()
-	{
+	inline void vector<T, Alloc>::emplace_back() {
 		buffer_append(&m_buffer);
 	}
 
 	template<typename T, typename Alloc>
 	template<typename Param>
-	inline void vector<T, Alloc>::emplace_back(const Param& param)
-	{
+	inline void vector<T, Alloc>::emplace_back(const Param& param) {
 		buffer_append(&m_buffer, &param);
 	}
 

--- a/include/TINYSTL/vector.h
+++ b/include/TINYSTL/vector.h
@@ -228,20 +228,20 @@ namespace tinystl {
 
 	template<typename T, typename Alloc>
 	inline void vector<T, Alloc>::push_back(const T& t) {
-		buffer_insert(&m_buffer, m_buffer.last, &t, &t + 1);
+		buffer_append(&m_buffer, &t);
 	}
 
 	template<typename T, typename Alloc>
 	inline void vector<T, Alloc>::emplace_back()
 	{
-		buffer_insert(&m_buffer, m_buffer.last, 1);
+		buffer_append(&m_buffer);
 	}
 
 	template<typename T, typename Alloc>
 	template<typename Param>
 	inline void vector<T, Alloc>::emplace_back(const Param& param)
 	{
-		buffer_insert(&m_buffer, m_buffer.last, &param, &param + 1);
+		buffer_append(&m_buffer, &param);
 	}
 
 	template<typename T, typename Alloc>


### PR DESCRIPTION
The pull request (unfortunately) mixes two improvements for tinystl::vector:
1. Fix for the memory leak in shrink_to_fit.
2. Performance improvement in vector::push_back()/emplace_back(): a fast-path is added for the most common case when it is a write + pointer increment. If required, I can present the results of benchmarks I ran.