### PR TITLE
Fix compiler warning

### DIFF
--- a/include/TINYSTL/buffer.h
+++ b/include/TINYSTL/buffer.h
@@ -224,11 +224,12 @@ namespace tinystl {
 			offset = (pointer)first - (pointer)b->first;
 			if ((pointer)where <= (pointer)first)
 				offset += count * sizeof(T);
-		}
-		where = buffer_insert_common(b, where, count);
-		if (frombuf) {
+			where = buffer_insert_common(b, where, count);
 			first = (Param*)((pointer)b->first + offset);
 			last = first + count;
+		}
+		else {
+			where = buffer_insert_common(b, where, count);
 		}
 		for (; first != last; ++first, ++where)
 			new(placeholder(), where) T(*first);


### PR DESCRIPTION
The initialization of the `offset` local variable depends on `frombuf`. However, due to the assignment to `where`, the if block that does stuff when `frombuf` is true (including initialization and usage of `offset`) was split in two, and `offset` was initialized in the first block, but used in the second. The compiler couldn't see the link between the two blocks, therefore I combined them into one. However, the assignment to `where` has to happen independently of `frombuf` on the one hand, and in the middle of the if block, on the other hand. Therefore, an else block was added, and the assignment to `where` duplicated. It's not the prettiest solution, but I don't like compiler warnings, and using #pragma would make it compiler-specific.
