### PR TITLE
Introduce tinystl.natvis

### DIFF
--- a/tinystl.natvis
+++ b/tinystl.natvis
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>  
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">  
+	<Type Name="tinystl::buffer&lt;*,*&gt;">
+		<DisplayString>{{ size={last - first} }}</DisplayString>
+		<Expand>
+			<Item Name="[size]">last - first</Item>
+			<Item Name="[capacity]">capacity - first</Item>
+			<ArrayItems>
+				<Size>last - first</Size>
+				<ValuePointer>first</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="tinystl::vector&lt;*,*&gt;">
+		<DisplayString>{{ size={m_buffer.last - m_buffer.first} }}</DisplayString>
+		<Expand>
+			<ExpandedItem>m_buffer</ExpandedItem>
+		</Expand>
+	</Type>
+
+	<Type Name="tinystl::unordered_set&lt;*,*&gt;">
+		<DisplayString>{{ size={m_size} }}</DisplayString>
+		<Expand>
+			<Item Name="[size]">m_size</Item>
+			<Item Name="[bucket_count]">m_buckets.last - m_buckets.first</Item>
+			<LinkedListItems>
+				<HeadPointer>*m_buckets.first</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode>first</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+	
+	<Type Name="tinystl::unordered_map&lt;*,*,*&gt;">
+		<DisplayString>{{ size={m_size} }}</DisplayString>
+		<Expand>
+			<Item Name="[size]">m_size</Item>
+			<Item Name="[bucket_count]">m_buckets.last - m_buckets.first</Item>
+			<LinkedListItems>
+				<HeadPointer>*m_buckets.first</HeadPointer>
+				<NextPointer>next</NextPointer>
+				<ValueNode Name="[{first}]">second</ValueNode>
+			</LinkedListItems>
+		</Expand>
+	</Type>
+
+	<Type Name="tinystl::basic_string&lt;*&gt;">
+		<DisplayString>{m_first,[m_last - m_first]na}</DisplayString>
+		<StringView>m_first,[m_last - m_first]na</StringView>
+		<Expand>
+			<Item Name="[size]">m_last - m_first</Item>
+			<Item Name="[capacity]">m_capacity - m_first</Item>
+			<ArrayItems>
+				<Size>m_last - m_first</Size>
+				<ValuePointer>m_first</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+
+	<Type Name="tinystl::string_view">
+		<DisplayString>{m_str,[m_size]na}</DisplayString>
+		<StringView>m_str,[m_size]na</StringView>
+		<Expand>
+			<Item Name="[size]">m_size</Item>
+			<ArrayItems>
+				<Size>m_size</Size>
+				<ValuePointer>m_str</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+</AutoVisualizer>


### PR DESCRIPTION
Based roughly on Visual Studio's conventions for containers.  Added a few extra "[size]" items that equivalent containers don't always have (e.g. Microsoft's basic_string has [size], but vector does not, whereas I've added it to both)

Closes #14 