### PR TITLE
Fix : remove allocation in instanciation of unordered map

### DIFF
--- a/include/TINYSTL/hash_base.h
+++ b/include/TINYSTL/hash_base.h
@@ -281,6 +281,7 @@ namespace tinystl {
 
 	template<typename Node, typename Key>
 	static inline Node unordered_hash_find(const Key& key, Node* buckets, size_t nbuckets) {
+		if (!buckets) return 0;
 		const size_t bucket = hash(key) & (nbuckets - 2);
 		for (Node it = buckets[bucket], end = buckets[bucket+1]; it != end; it = it->next)
 			if (it->first == key)

--- a/include/TINYSTL/unordered_map.h
+++ b/include/TINYSTL/unordered_map.h
@@ -85,7 +85,6 @@ namespace tinystl {
 		: m_size(0)
 	{
 		buffer_init<pointer, Alloc>(&m_buckets);
-		buffer_resize<pointer, Alloc>(&m_buckets, 9, 0);
 	}
 
 	template<typename Key, typename Value, typename Alloc>
@@ -230,6 +229,7 @@ namespace tinystl {
 		unordered_hash_node<Key, Value>* newnode = new(placeholder(), Alloc::static_allocate(sizeof(unordered_hash_node<Key, Value>))) unordered_hash_node<Key, Value>(p.first, p.second);
 		newnode->next = newnode->prev = 0;
 
+		if(!m_buckets.first) buffer_resize<pointer, Alloc>(&m_buckets, 9, 0);
 		const size_t nbuckets = (size_t)(m_buckets.last - m_buckets.first);
 		unordered_hash_node_insert(newnode, hash(p.first), m_buckets.first, nbuckets - 1);
 
@@ -254,6 +254,7 @@ namespace tinystl {
 		unordered_hash_node<Key, Value>* newnode = new(placeholder(), Alloc::static_allocate(sizeof(unordered_hash_node<Key, Value>))) unordered_hash_node<Key, Value>(static_cast<Key&&>(p.first), static_cast<Value&&>(p.second));
 		newnode->next = newnode->prev = 0;
 
+		if (!m_buckets.first) buffer_resize<pointer, Alloc>(&m_buckets, 9, 0);
 		const size_t nbuckets = (size_t)(m_buckets.last - m_buckets.first);
 		unordered_hash_node_insert(newnode, keyhash, m_buckets.first, nbuckets - 1);
 


### PR DESCRIPTION
In my own project I need to load a dll with static unordered map without allocation, allocation inside the dll are wrapped and the allocator is set after the loading of the dll by the main executable.

So I removed the automatic allocation inside unordered map constructor.
I checked with auto-test and everything went fine.