### PR TITLE
Fix undefined behaviour (arithmetic on null pointer)

### DIFF
--- a/include/TINYSTL/buffer.h
+++ b/include/TINYSTL/buffer.h
@@ -141,7 +141,7 @@ namespace tinystl {
 
 	template<typename T, typename Alloc>
 	static inline void buffer_reserve(buffer<T, Alloc>* b, size_t capacity) {
-		if (b->first + capacity <= b->capacity)
+		if (b->first && b->first + capacity <= b->capacity)
 			return;
 
 		typedef T* pointer;


### PR DESCRIPTION
This is being caught be clang's undefined behaviour sanitiser. 
See https://godbolt.org/z/nWf48K
Normally I wouldn't worry about this sort of language-lawyer level thing but it's making tinystl unusable with the sanitiser.